### PR TITLE
Adjust styles for smaller screens

### DIFF
--- a/static/css/responsive.css
+++ b/static/css/responsive.css
@@ -1,0 +1,60 @@
+/* responsive.css */
+@media (max-width: 768px) {
+    header {
+        padding: 16px;
+    }
+    
+    h1 {
+        font-size: 24px;
+    }
+    
+    main {
+        grid-template-columns: 1fr;
+        padding: 16px;
+        gap: 12px;
+    }
+    
+    .card {
+        padding: 12px;
+    }
+}
+
+@media (max-width: 480px) {
+    header {
+        padding: 12px;
+    }
+    
+    h1 {
+        font-size: 20px;
+    }
+    
+    header p {
+        font-size: 14px;
+    }
+    
+    main {
+        padding: 12px;
+        gap: 10px;
+    }
+    
+    .card {
+        padding: 10px;
+    }
+    
+    .card h2 {
+        font-size: 18px;
+    }
+    
+    input, button {
+        font-size: 14px;
+    }
+    
+    pre {
+        font-size: 12px;
+    }
+    
+    footer {
+        font-size: 12px;
+        padding: 12px;
+    }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Magic AI Builder</title>
     <link rel="stylesheet" href="/static/css/styles.css" />
+    <link rel="stylesheet" href="/static/css/responsive.css" />
   </head>
   <body>
     <header>


### PR DESCRIPTION
Add `responsive.css` to provide mobile-responsive styles for the Magic AI Builder application.

The initial CSS provided by the user referenced classes not present in the Magic AI Builder application. This PR introduces responsive styles specifically for the existing UI elements (e.g., `main`, `.card`, `header`) to ensure proper display on smaller screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-967f4967-2592-4853-a461-86f3d0e615df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-967f4967-2592-4853-a461-86f3d0e615df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

