### PR TITLE
Adjust styles for smaller screens

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -10,3 +10,21 @@ button { margin-top: 8px; padding: 10px 14px; border: 0; border-radius: 8px; bac
 button:hover { background: #4263eb; }
 pre { background: rgba(0,0,0,0.4); padding: 8px; border-radius: 8px; overflow-x: auto; }
 footer { padding: 16px; text-align: center; opacity: 0.7; }
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  header { padding: 16px; }
+  h1 { font-size: 24px; }
+  main {
+    grid-template-columns: 1fr;
+    padding: 16px;
+  }
+  .card { padding: 12px; }
+}
+
+@media (max-width: 480px) {
+  header { padding: 12px; }
+  main { padding: 12px; }
+  button { width: 100%; }
+  pre { font-size: 12px; }
+}


### PR DESCRIPTION
Add responsive CSS rules to `static/css/styles.css` to improve layout on screens up to 768px and 480px.

The classes provided in the initial request (`.quantum-dashboard`, `.bots-grid`, etc.) were not found in the codebase. This PR implements equivalent responsive adjustments by targeting existing selectors (`header`, `h1`, `main`, `.card`, `button`, `pre`) to ensure the layout adapts appropriately on smaller screen sizes.

---
<a href="https://cursor.com/background-agent?bcId=bc-07796b50-36fa-482b-88b5-c905d33d75a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-07796b50-36fa-482b-88b5-c905d33d75a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

